### PR TITLE
development-queue

### DIFF
--- a/XSOverlay VRChat Parser/Avalonia/Views/MainWindow.axaml.cs
+++ b/XSOverlay VRChat Parser/Avalonia/Views/MainWindow.axaml.cs
@@ -1,7 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using Avalonia.Media;
 using Avalonia.Threading;
 using AvaloniaEdit;
 using AvaloniaEdit.Highlighting;

--- a/XSOverlay VRChat Parser/Models/ConfigurationModel.cs
+++ b/XSOverlay VRChat Parser/Models/ConfigurationModel.cs
@@ -51,10 +51,6 @@ namespace XSOverlay_VRChat_Parser.Models
 
         [Annotation("Determines whether or not world change notifications are delivered. Valid values: true, false", true, "WORLD CHANGED")]
         public bool DisplayWorldChanged { get; set; }
-        [Annotation("Period of time in seconds for player join/leave notifications to be silenced on world join. This is to avoid spam from enumerating everyone currently in the target world. Valid values: 0.0 -> float32 max")]
-        public long WorldJoinSilenceSeconds { get; set; }
-        [Annotation("Determines whether or not player join/leave notifications are silenced on world join. Warning, this gets spammy if on! Valid values: true, false")]
-        public bool DisplayJoinLeaveSilencedOverride { get; set; }
         [Annotation("Period of time in seconds for the world changed notification to remain on screen. Value values: 0.0 -> float32 max")]
         public float WorldChangedNotificationTimeoutSeconds { get; set; }
         [Annotation("Volume for incoming notification sounds. Valid values: 0.0 -> 1.0.")]
@@ -109,8 +105,6 @@ namespace XSOverlay_VRChat_Parser.Models
             PlayerLeftAudioPath = @"\Resources\Audio\player_left.ogg";
 
             DisplayWorldChanged = true;
-            WorldJoinSilenceSeconds = 20;
-            DisplayJoinLeaveSilencedOverride = false;
             WorldChangedNotificationTimeoutSeconds = 3.0f;
             WorldChangedNotificationVolume = 0.2f;
             WorldChangedIconPath = @"\Resources\Icons\world_changed.png";

--- a/XSOverlay VRChat Parser/Models/NotificationDispatchModel.cs
+++ b/XSOverlay VRChat Parser/Models/NotificationDispatchModel.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using XSNotifications;
 using XSOverlay_VRChat_Parser.Helpers;
 

--- a/XSOverlay VRChat Parser/Models/NotificationDispatchModel.cs
+++ b/XSOverlay VRChat Parser/Models/NotificationDispatchModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XSNotifications;
+using XSOverlay_VRChat_Parser.Helpers;
+
+namespace XSOverlay_VRChat_Parser.Models
+{
+    class NotificationDispatchModel
+    {
+        public int DurationMilliseconds { get; set; }
+        public EventType Type { get; set; }
+        public XSNotification Message { get; set; }
+        public bool WasGrouped { get; set; }
+        public List<NotificationDispatchModel> GroupedNotifications { get; set; }
+
+        public NotificationDispatchModel()
+        {
+            WasGrouped = false;
+            GroupedNotifications = new List<NotificationDispatchModel>();
+        }
+    }
+}

--- a/XSOverlay VRChat Parser/Program.cs
+++ b/XSOverlay VRChat Parser/Program.cs
@@ -43,8 +43,7 @@ namespace XSOverlay_VRChat_Parser
 
         static Dictionary<string, TailSubscription> Subscriptions { get; set; }
 
-        static DateTime SilencedUntil = DateTime.Now,
-                        LastMaximumKeywordsNotification = DateTime.Now;
+        static DateTime LastMaximumKeywordsNotification = DateTime.Now;
 
         static XSNotifier Notifier { get; set; }
 
@@ -393,7 +392,7 @@ namespace XSOverlay_VRChat_Parser
                 }
             }
 
-            if(instanceCap > 0)
+            if (instanceCap > 0)
             {
                 // Read was presumably a success. Write values.
                 IsKnownPlayerCap = true;
@@ -598,7 +597,7 @@ namespace XSOverlay_VRChat_Parser
                                 Volume = Configuration.MaximumKeywordsExceededNotificationVolume
                             }));
 
-                            if(DateTime.Now > LastMaximumKeywordsNotification.AddSeconds(Configuration.MaximumKeywordsExceededCooldownSeconds))
+                            if (DateTime.Now > LastMaximumKeywordsNotification.AddSeconds(Configuration.MaximumKeywordsExceededCooldownSeconds))
                                 Log(LogEventType.Event, $"Maximum shader keywords exceeded!");
                         }
                         // Portal dropped

--- a/XSOverlay VRChat Parser/Resources/EventLogSH.xshd
+++ b/XSOverlay VRChat Parser/Resources/EventLogSH.xshd
@@ -26,19 +26,19 @@
       \[\d{2}:\d{2}:\d{2}\]
     </Rule>
     <Rule color="VRCWorldChange">
-      \bWorld.*
+      (\bWorld.*)|(\bDiscovered.*)|(\bRewinding.*)
     </Rule>
     <Rule color="VRCPlayerJoined">
-      \bJoin:.*
+      \[(\d+|\?+)/(\d+|\?+)\].Join:.*
     </Rule>
     <Rule color="VRCPlayerLeft">
-      \bLeave:.*
+      \[(\d+|\?+)/(\d+|\?+)\].Leave:.*
     </Rule>
     <Keywords color="VRCPortalDropped">
       <Word>Portal dropped.</Word>
     </Keywords>
     <Keywords color="VRCShaderKeywords">
-      <Word>/Word>Maximum shader keyword exceeded!</Word>
+      <Word>Maximum shader keyword exceeded!</Word>
     </Keywords>
 </RuleSet>
 

--- a/XSOverlay VRChat Parser/XSOverlay VRChat Parser.csproj
+++ b/XSOverlay VRChat Parser/XSOverlay VRChat Parser.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>XSOverlay_VRChat_Parser</RootNamespace>
     <Platforms>AnyCPU;x64</Platforms>
+    <Version>0.22</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Added a dispatch queue that dispatches messages as the previous message reaches its timeout rather than firing and forgetting. This enables us to have better, more reliable batching and take other actions in the future based on future messages in the queue.
- Fixed a syntax highlighting issue preventing the shader keywords exceeded message from being appropriately highlighted.
- Added retroactive log parsing to obtain instance metadata for cases where the parser is started mid-instance.
- Added the tracking of player counts and the current instance cap. Counts and cap are shown in join and leave messages. 
- Vastly improved batching behavior because of dispatch queue.
- Removed silencing on world change because it's no longer necessary due to improved batching behavior.
- Limited shader keywords message display in the GUI according to the same cooldown specified for displaying it in XSO.