### PR TITLE
Fixed not being able to receive Maximum Shader Keywords exceeded with…

### DIFF
--- a/XSOverlay VRChat Parser/Program.cs
+++ b/XSOverlay VRChat Parser/Program.cs
@@ -113,6 +113,7 @@ namespace XSOverlay_VRChat_Parser
             IgnorableIconPaths.Add(XSGlobals.GetBuiltInIconTypeString(XSIconDefaults.Error));
 
             Subscriptions = new Dictionary<string, TailSubscription>();
+            LastMaximumKeywordsNotification = now.AddSeconds(-Configuration.MaximumKeywordsExceededCooldownSeconds);
             LogDetectionTimer = new Timer(new TimerCallback(LogDetectionTick), null, 0, Configuration.DirectoryPollFrequencyMilliseconds);
 
             Log(LogEventType.Info, $"Log detection timer initialized with poll frequency {Configuration.DirectoryPollFrequencyMilliseconds} and parse frequency {Configuration.ParseFrequencyMilliseconds}.");


### PR DESCRIPTION
…in the amount specified in ConfigurationModel.MaximumKeywordsExceededCooldownSeconds after starting